### PR TITLE
ISO message header support

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583Constant.java
+++ b/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583Constant.java
@@ -22,6 +22,7 @@ package org.wso2.carbon.connector.iso8583;
 public class ISO8583Constant {
     public final static String TAG_FIELD = "field";
     public final static String TAG_DATA = "data";
+    public final static String HEADER = "header";
     public final static String TAG_ID = "id";
     public final static String PORT = "uri.var.serverPort";
     public final static String HOST = "uri.var.serverHost";

--- a/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583MessageHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583MessageHandler.java
@@ -116,6 +116,9 @@ public class ISO8583MessageHandler {
     public void messageBuilder(MessageContext messageContext, ISOMsg isomsg) {
         OMFactory OMfactory = OMAbstractFactory.getOMFactory();
         OMElement parentElement = OMfactory.createOMElement(ISO8583Constant.TAG_MSG, null);
+        OMElement header = OMfactory.createOMElement(ISO8583Constant.HEADER, null);
+        header.setText(new String(isomsg.getHeader()));
+        parentElement.addChild(header);
         OMElement result = OMfactory.createOMElement(ISO8583Constant.TAG_DATA, null);
         for (int i = 0; i <= isomsg.getMaxField(); i++) {
             if (isomsg.hasField(i)) {

--- a/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583MessageHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583MessageHandler.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.connector.iso8583;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
+import org.apache.axiom.soap.SOAPEnvelope;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
@@ -32,6 +33,9 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Socket;
+import java.util.Base64;
+import java.util.Iterator;
+import javax.xml.namespace.QName;
 
 /**
  * Class for handling the iso message request and responses.
@@ -97,7 +101,8 @@ public class ISO8583MessageHandler {
      */
     public void unpackResponse(MessageContext messageContext, String message) {
         try {
-            ISOPackager packager = ISO8583PackagerFactory.getPackager();
+            int headerLength = getHeaderLength(messageContext);
+            ISOPackager packager = ISO8583PackagerFactory.getPackager(headerLength);
             ISOMsg isoMsg = new ISOMsg();
             isoMsg.setPackager(packager);
             isoMsg.unpack(message.getBytes());
@@ -105,6 +110,16 @@ public class ISO8583MessageHandler {
         } catch (ISOException e) {
             handleException("Couldn't unpack the message since message is not in ISO Standard :" + message, e);
         }
+    }
+
+    private int getHeaderLength(MessageContext messageContext) {
+        int headerLength = 0;
+        SOAPEnvelope soapEnvelope = messageContext.getEnvelope();
+        OMElement getElements = soapEnvelope.getBody().getFirstElement();
+        OMElement header = getElements.getFirstChildWithName(new QName(ISO8583Constant.HEADER));
+        if (header != null)
+            headerLength = (Base64.getDecoder().decode(header.getText())).length;
+        return headerLength;
     }
 
     /**
@@ -116,9 +131,11 @@ public class ISO8583MessageHandler {
     public void messageBuilder(MessageContext messageContext, ISOMsg isomsg) {
         OMFactory OMfactory = OMAbstractFactory.getOMFactory();
         OMElement parentElement = OMfactory.createOMElement(ISO8583Constant.TAG_MSG, null);
-        OMElement header = OMfactory.createOMElement(ISO8583Constant.HEADER, null);
-        header.setText(new String(isomsg.getHeader()));
-        parentElement.addChild(header);
+        if (isomsg.getHeader() != null) {
+            OMElement header = OMfactory.createOMElement(ISO8583Constant.HEADER, null);
+            header.setText(Base64.getEncoder().encodeToString(isomsg.getHeader()));
+            parentElement.addChild(header);
+        }
         OMElement result = OMfactory.createOMElement(ISO8583Constant.TAG_DATA, null);
         for (int i = 0; i <= isomsg.getMaxField(); i++) {
             if (isomsg.hasField(i)) {

--- a/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583MessageProducer.java
+++ b/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583MessageProducer.java
@@ -56,6 +56,9 @@ public class ISO8583MessageProducer extends AbstractConnector {
             OMElement getElements = soapEnvelope.getBody().getFirstElement();
             ISOMsg isoMsg = new ISOMsg();
             isoMsg.setPackager(packager);
+            String header = getElements.getFirstChildWithName(
+                    new QName(ISO8583Constant.HEADER)).getText();
+            isoMsg.setHeader(header.getBytes());
             Iterator fields = getElements.getFirstChildWithName(
                     new QName(ISO8583Constant.TAG_DATA)).getChildrenWithLocalName(ISO8583Constant.TAG_FIELD);
             while (fields.hasNext()) {

--- a/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583MessageProducer.java
+++ b/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583MessageProducer.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 
 import javax.xml.namespace.QName;
+import java.util.Base64;
 import java.util.Iterator;
 
 /**
@@ -51,14 +52,16 @@ public class ISO8583MessageProducer extends AbstractConnector {
      */
     public void packedISO8583Message(MessageContext msgContext, String host, int port) {
         try {
-            ISOPackager packager = ISO8583PackagerFactory.getPackager();
             SOAPEnvelope soapEnvelope = msgContext.getEnvelope();
             OMElement getElements = soapEnvelope.getBody().getFirstElement();
             ISOMsg isoMsg = new ISOMsg();
-            isoMsg.setPackager(packager);
-            String header = getElements.getFirstChildWithName(
-                    new QName(ISO8583Constant.HEADER)).getText();
-            isoMsg.setHeader(header.getBytes());
+            int headerLength = 0;
+            OMElement header = getElements.getFirstChildWithName(new QName(ISO8583Constant.HEADER));
+            if (header != null) {
+                isoMsg.setHeader(Base64.getDecoder().decode(header.getText()));
+                headerLength = (Base64.getDecoder().decode(header.getText())).length;
+            }
+            isoMsg.setPackager(ISO8583PackagerFactory.getPackager(headerLength));
             Iterator fields = getElements.getFirstChildWithName(
                     new QName(ISO8583Constant.TAG_DATA)).getChildrenWithLocalName(ISO8583Constant.TAG_FIELD);
             while (fields.hasNext()) {

--- a/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583PackagerFactory.java
+++ b/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583PackagerFactory.java
@@ -16,9 +16,12 @@
 
 package org.wso2.carbon.connector.iso8583;
 
+import org.apache.synapse.SynapseException;
+import org.jpos.iso.ISOBasePackager;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOPackager;
 import org.jpos.iso.packager.GenericPackager;
+
 
 public class ISO8583PackagerFactory {
     /**
@@ -28,5 +31,30 @@ public class ISO8583PackagerFactory {
         ISOPackager packager;
         packager = new GenericPackager(ISO8583Constant.PACKAGER);
         return packager;
+    }
+
+    public static ISOBasePackager getPackager(int headerLength) {
+        ISOBasePackager packager = null;
+        try {
+            headerLength = headerLength > -1 ? headerLength : 0;
+            ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            packager = new GenericPackager(loader.getResourceAsStream(ISO8583Constant.PACKAGER));
+            packager.setHeaderLength(headerLength);
+        } catch (NumberFormatException e) {
+            handleException("One of the properties are of an invalid type", e);
+        } catch (ISOException e) {
+            handleException("Error while get the ISOPackager", e);
+        }
+        return packager;
+    }
+
+    /**
+     * handle the Exception
+     *
+     * @param msg error message
+     * @param e   an Exception
+     */
+    private static void handleException(String msg, Exception e) {
+        throw new SynapseException(msg, e);
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583PackagerFactory.java
+++ b/src/main/java/org/wso2/carbon/connector/iso8583/ISO8583PackagerFactory.java
@@ -22,7 +22,6 @@ import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOPackager;
 import org.jpos.iso.packager.GenericPackager;
 
-
 public class ISO8583PackagerFactory {
     /**
      * get the ISO Packager
@@ -33,6 +32,9 @@ public class ISO8583PackagerFactory {
         return packager;
     }
 
+    /**
+     * get the ISO Packager for given HeaderLength
+     */
     public static ISOBasePackager getPackager(int headerLength) {
         ISOBasePackager packager = null;
         try {


### PR DESCRIPTION
## Purpose
The current Implementation doesn't support the message with different header length

## Goals
Implement the connector to support iso8583 message with header

## Approach
Get encoded header in the XML format message 

## User stories


## Release note


## Documentation


## Training


## Certification


## Marketing


## Automation tests


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples


## Related PRs


## Migrations (if applicable)


## Test environment
JDK versions-1.8
Operating systems-Ubuntu 16.04
Product- EI-6.1.1
 
